### PR TITLE
.as_finite_difference, differentiate_finite

### DIFF
--- a/doc/src/tutorial/calculus.rst
+++ b/doc/src/tutorial/calculus.rst
@@ -311,19 +311,33 @@ The ``O`` notation supports arbitrary limit points (other than 0):
 Finite differences
 ==================
 
-So far we have looked at expressions with analytical derivatives
+So far we have looked at expressions with analytic derivatives
 and primitive functions respectively. But what if we want to have an
 expression to estimate a derivative of a curve for which we lack a
 closed form representation, or for which we don't know the functional
 values for yet. One approach would be to use a finite difference
 approach.
 
-You can use the ``as_finite_diff`` method of on any ``Derivative``
-instance to generate approximations to derivatives of arbitrary order:
+The simplest way the differentiate using finite differences is to use
+the ``differentiate_finite`` function:
+
+    >>> f, g = symbols('f g', cls=Function)
+    >>> differentiate_finite(f(x)*g(x))
+    (-f(x - 1/2) + f(x + 1/2))⋅g(x) + (-g(x - 1/2) + g(x + 1/2))⋅f(x)
+
+If we don't want to expand the intermediate derivative we may pass the
+flag ``evaluate=False``:
+
+    >>> differentiate_finite(f(x)*g(x), evaluate=False)
+    -f(x - 1/2)⋅g(x - 1/2) + f(x + 1/2)⋅g(x + 1/2)
+
+If you already have a ``Derivative`` instance, you can use the
+``as_finite_difference`` method to generate approximations of the
+derivative to arbitrary order:
 
     >>> f = Function('f')
     >>> dfdx = f(x).diff(x)
-    >>> as_finite_diff(dfdx)
+    >>> dfdx.as_finite_difference()
     -f(x - 1/2) + f(x + 1/2)
 
 here the first order derivative was approximated around x using a
@@ -334,7 +348,7 @@ equidistantly using a step-size of 1. We can use arbitrary steps
     >>> f = Function('f')
     >>> d2fdx2 = f(x).diff(x, 2)
     >>> h = Symbol('h')
-    >>> as_finite_diff(d2fdx2, [-3*h,-h,2*h])
+    >>> d2fdx2.as_finite_difference([-3*h,-h,2*h])
     f(-3⋅h)   f(-h)   2⋅f(2⋅h)
     ─────── - ───── + ────────
          2        2        2
@@ -347,15 +361,15 @@ manually:
     [1/5, -1/3, 2/15]
 
 note that we only need the last element in the last sublist
-returned from finite_diff_weights. The reason for this is that
-finite_diff_weights also generates weights for lower derivatives and
+returned from ``finite_diff_weights``. The reason for this is that
+the function also generates weights for lower derivatives and
 using fewer points (see the documentation of ``finite_diff_weights``
 for more details).
 
-if using ``finite_diff_weights`` directly looks complicated and the
-``as_finite_diff`` function operating on ``Derivative`` instances
+if using ``finite_diff_weights`` directly looks complicated, and the
+``as_finite_difference`` method of ``Derivative`` instances
 is not flexible enough, you can use ``apply_finite_diff`` which
-takes order, x_list, y_list and x0 as parameters:
+takes ``order``, ``x_list``, ``y_list`` and ``x0`` as parameters:
 
     >>> x_list = [-3, 1, 2]
     >>> y_list = symbols('a b c')

--- a/sympy/calculus/__init__.py
+++ b/sympy/calculus/__init__.py
@@ -6,5 +6,5 @@ from .euler import euler_equations
 from .singularities import (singularities, is_increasing,
                             is_strictly_increasing, is_decreasing,
                             is_strictly_decreasing, is_monotonic)
-from .finite_diff import finite_diff_weights, apply_finite_diff, as_finite_diff
+from .finite_diff import finite_diff_weights, apply_finite_diff, as_finite_diff, differentiate_finite
 from .util import not_empty_in, AccumBounds

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -7,27 +7,30 @@ difference weights for ordinary differentials of functions for
 derivatives from 0 (interpolation) up to arbitrary order.
 
 The core algorithm is provided in the finite difference weight generating
-function (finite_diff_weights), and two convenience functions are provided
+function (``finite_diff_weights``), and two convenience functions are provided
 for:
 
 - estimating a derivative (or interpolate) directly from a series of points
     is also provided (``apply_finite_diff``).
-- making a finite difference approximation of a Derivative instance
-    (``as_finite_diff``).
+- differentiating by using finite difference approximations
+    (``differentiate_finite``).
 
 """
 
-from sympy import S
+from functools import reduce
+from operator import add
+
+from sympy import Derivative, S
 from sympy.core.compatibility import iterable, range
+from sympy.core.decorators import deprecated
 
 
 def finite_diff_weights(order, x_list, x0=S(0)):
     """
-    Calculates the finite difference weights for an arbitrarily
-    spaced one-dimensional grid (x_list) for derivatives at 'x0'
-    of order 0, 1, ..., up to 'order' using a recursive formula.
-    Order of accuracy is at least len(x_list) - order, if x_list
-    is defined accurately.
+    Calculates the finite difference weights for an arbitrarily spaced
+    one-dimensional grid (``x_list``) for derivatives at ``x0`` of order
+    0, 1, ..., up to 'order' using a recursive formula. Order of accuracy
+    is at least ``len(x_list) - order``, if ``x_list`` is defined correctly.
 
 
     Parameters
@@ -79,9 +82,9 @@ def finite_diff_weights(order, x_list, x0=S(0)):
     7/8
 
     Each sublist contains the most accurate formula at the end.
-    Note, that in the above example res[1][1] is the same as res[1][2].
+    Note, that in the above example ``res[1][1]`` is the same as ``res[1][2]``.
     Since res[1][2] has an order of accuracy of
-    len(x_list[:3]) - order = 3 - 1 = 2, the same is true for res[1][1]!
+    ``len(x_list[:3]) - order = 3 - 1 = 2``, the same is true for ``res[1][1]``!
 
     >>> from sympy import S
     >>> from sympy.calculus import finite_diff_weights
@@ -101,8 +104,8 @@ def finite_diff_weights(order, x_list, x0=S(0)):
     >>> res[3:]  # higher order approximations
     [[-1/2, 1, -1/3, -1/6, 0], [0, 2/3, -2/3, -1/12, 1/12]]
 
-    Let us compare this to a differently defined x_list. Pay attention to
-    foo[i][k] corresponding to the gridpoint defined by x_list[k].
+    Let us compare this to a differently defined ``x_list``. Pay attention to
+    ``foo[i][k]`` corresponding to the gridpoint defined by ``x_list[k]``.
 
     >>> from sympy import S
     >>> from sympy.calculus import finite_diff_weights
@@ -121,7 +124,7 @@ def finite_diff_weights(order, x_list, x0=S(0)):
     [1/12, -2/3, 0, 2/3, -1/12]
 
     Note that, unless you plan on using approximations based on subsets of
-    x_list, the order of gridpoints does not matter.
+    ``x_list``, the order of gridpoints does not matter.
 
 
     The capability to generate weights at arbitrary points can be
@@ -146,11 +149,11 @@ def finite_diff_weights(order, x_list, x0=S(0)):
 
     If weights for a finite difference approximation of 3rd order
     derivative is wanted, weights for 0th, 1st and 2nd order are
-    calculated "for free", so are formulae using subsets of x_list.
+    calculated "for free", so are formulae using subsets of ``x_list``.
     This is something one can take advantage of to save computational cost.
-    Be aware that one should define x_list from nearest to farest from
-    x_list. If not, subsets of x_list will yield poorer approximations,
-    which might not grand an order of accuracy of len(x_list) - order.
+    Be aware that one should define ``x_list`` from nearest to farest from
+    ``x0``. If not, subsets of ``x_list`` will yield poorer approximations,
+    which might not grand an order of accuracy of ``len(x_list) - order``.
 
     See also
     ========
@@ -198,8 +201,8 @@ def finite_diff_weights(order, x_list, x0=S(0)):
 def apply_finite_diff(order, x_list, y_list, x0=S(0)):
     """
     Calculates the finite difference approximation of
-    the derivative of requested order at x0 from points
-    provided in x_list and y_list.
+    the derivative of requested order at ``x0`` from points
+    provided in ``x_list`` and ``y_list``.
 
     Parameters
     ==========
@@ -220,7 +223,7 @@ def apply_finite_diff(order, x_list, y_list, x0=S(0)):
 
     sympy.core.add.Add or sympy.core.numbers.Number
         The finite difference expression approximating the requested
-        derivative order at x0.
+        derivative order at ``x0``.
 
     Examples
     ========
@@ -283,7 +286,7 @@ def apply_finite_diff(order, x_list, y_list, x0=S(0)):
     return derivative
 
 
-def as_finite_diff(derivative, points=1, x0=None, wrt=None):
+def _as_finite_diff(derivative, points=1, x0=None, wrt=None):
     """
     Returns an approximation of a derivative of a function in
     the form of a finite difference formula. The expression is a
@@ -293,8 +296,7 @@ def as_finite_diff(derivative, points=1, x0=None, wrt=None):
     Parameters
     ==========
 
-    derivative: a Derivative instance (needs to have an variables
-        and expr attribute).
+    derivative: a Derivative instance
 
     points: sequence or coefficient, optional
         If sequence: discrete values (length >= order+1) of the
@@ -302,22 +304,25 @@ def as_finite_diff(derivative, points=1, x0=None, wrt=None):
         difference weights.
         If it is a coefficient, it will be used as the step-size
         for generating an equidistant sequence of length order+1
-        centered around x0. default: 1 (step-size 1)
+        centered around ``x0``. default: 1 (step-size 1)
 
     x0: number or Symbol, optional
-        the value of the independent variable (wrt) at which the
-        derivative is to be approximated. default: same as wrt
+        the value of the independent variable (``wrt``) at which the
+        derivative is to be approximated. Default: same as ``wrt``.
 
     wrt: Symbol, optional
         "with respect to" the variable for which the (partial)
         derivative is to be approximated for. If not provided it
-        is required that the Derivative is ordinary. default: None
+        is required that the Derivative is ordinary. Default: ``None``.
 
 
     Examples
     ========
 
     >>> from sympy import symbols, Function, exp, sqrt, Symbol, as_finite_diff
+    >>> from sympy.utilities.exceptions import SymPyDeprecationWarning
+    >>> import warnings
+    >>> warnings.simplefilter("ignore", SymPyDeprecationWarning)
     >>> x, h = symbols('x h')
     >>> f = Function('f')
     >>> as_finite_diff(f(x).diff(x))
@@ -336,7 +341,7 @@ def as_finite_diff(derivative, points=1, x0=None, wrt=None):
     -3*f(x)/(2*h) + 2*f(h + x)/h - f(2*h + x)/(2*h)
 
     The algorithm is not restricted to use equidistant spacing, nor
-    do we need to make the approximation around x0, but we can get
+    do we need to make the approximation around ``x0``, but we can get
     an expression estimating the derivative at an offset:
 
     >>> e, sq2 = exp(1), sqrt(2)
@@ -352,7 +357,7 @@ def as_finite_diff(derivative, points=1, x0=None, wrt=None):
     >>> y = Symbol('y')
     >>> d2fdxdy=f(x,y).diff(x,y)
     >>> as_finite_diff(d2fdxdy, wrt=x)
-    -f(x - 1/2, y) + f(x + 1/2, y)
+    -Derivative(f(x - 1/2, y), y) + Derivative(f(x + 1/2, y), y)
 
     See also
     ========
@@ -361,12 +366,23 @@ def as_finite_diff(derivative, points=1, x0=None, wrt=None):
     sympy.calculus.finite_diff.finite_diff_weights
 
     """
+    if derivative.is_Derivative:
+        pass
+    elif derivative.is_Atom:
+        return derivative
+    else:
+        return derivative.fromiter(
+            [_as_finite_diff(ar, points, x0, wrt) for ar
+             in derivative.args], **derivative.assumptions0)
+
     if wrt is None:
-        wrt = derivative.variables[0]
-        # we need Derivative to be univariate to guess wrt
-        if any(v != wrt for v in derivative.variables):
-            raise ValueError('if the function is not univariate' +
-                             ' then `wrt` must be given')
+        old = None
+        for v in derivative.variables:
+            if old is v:
+                continue
+            derivative = _as_finite_diff(derivative, points, x0, v)
+            old = v
+        return derivative
 
     order = derivative.variables.count(wrt)
 
@@ -382,10 +398,73 @@ def as_finite_diff(derivative, points=1, x0=None, wrt=None):
                       in range(-order//2, order//2 + 1)]
         else:
             # odd order => even number of points, half-way wrt grid point
-            points = [x0 + points*i/S(2) for i
+            points = [x0 + points*S(i)/2 for i
                       in range(-order, order + 1, 2)]
-
+    others = [wrt, 0]
+    for v in set(derivative.variables):
+        if v == wrt:
+            continue
+        others += [v, derivative.variables.count(v)]
     if len(points) < order+1:
         raise ValueError("Too few points for order %d" % order)
     return apply_finite_diff(order, points, [
-        derivative.expr.subs({wrt: x}) for x in points], x0)
+        Derivative(derivative.expr.subs({wrt: x}), *others) for
+        x in points], x0)
+
+
+as_finite_diff = deprecated(useinstead="Derivative.as_finite_difference",
+                            deprecated_since_version="1.1")(_as_finite_diff)
+
+
+def differentiate_finite(expr, *symbols,
+                         # points=1, x0=None, wrt=None, evaluate=True, #Py2:
+                         **kwargs):
+    """ Differentiate f and replace Derivatives with finite differences.
+
+    Parameters
+    ==========
+    expr : expression
+    \*symbols : differentiate with respect to symbols
+    points: sequence or coefficient, optional
+        see ``Derivative.as_finite_difference``
+    x0: number or Symbol, optional
+        see ``Derivative.as_finite_difference``
+    wrt: Symbol, optional
+        see ``Derivative.as_finite_difference``
+    evaluate : bool
+        kwarg passed on to ``diff`` (whether or not to
+        evaluate the Derivative intermediately).
+
+
+    Examples
+    ========
+
+    >>> from sympy import cos, sin, Function, differentiate_finite
+    >>> from sympy.abc import x, y, h
+    >>> f = Function('f')
+    >>> differentiate_finite(f(x) + sin(x), x, 2)
+    -2*f(x) + f(x - 1) + f(x + 1) - sin(x)
+    >>> differentiate_finite(f(x) + sin(x), x, 2, evaluate=False)
+    -2*f(x) + f(x - 1) + f(x + 1) - 2*sin(x) + sin(x - 1) + sin(x + 1)
+    >>> differentiate_finite(f(x, y), x, y)
+    f(x - 1/2, y - 1/2) - f(x - 1/2, y + 1/2) - f(x + 1/2, y - 1/2) + \
+f(x + 1/2, y + 1/2)
+    >>> g = Function('g')
+    >>> differentiate_finite(f(x)*g(x), x, points=[x-h, x+h]).simplify()
+    -((f(-h + x) - f(h + x))*g(x) + (g(-h + x) - g(h + x))*f(x))/(2*h)
+    >>> differentiate_finite(f(x)*g(x), x, points=[x-h, x+h], evaluate=False)
+    -f(-h + x)*g(-h + x)/(2*h) + f(h + x)*g(h + x)/(2*h)
+
+    """
+    # Key-word only arguments only available in Python 3
+    points = kwargs.pop('points', 1)
+    x0 = kwargs.pop('x0', None)
+    wrt = kwargs.pop('wrt', None)
+    evaluate = kwargs.pop('evaluate', True)
+    if kwargs != {}:
+        raise ValueError("Unknown kwargs: %s" % kwargs)
+
+    Dexpr = expr.diff(*symbols, evaluate=evaluate)
+    return Dexpr.replace(
+        lambda arg: arg.is_Derivative,
+        lambda arg: arg.as_finite_difference(points=points, x0=x0, wrt=wrt))

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1367,6 +1367,78 @@ class Derivative(Expr):
         args = [arg._sage_() for arg in self.args]
         return sage.derivative(*args)
 
+    def as_finite_difference(self, points=1, x0=None, wrt=None):
+        """ Expresses a Derivative instance as a finite difference.
+
+        Parameters
+        ==========
+        points : sequence or coefficient, optional
+            If sequence: discrete values (length >= order+1) of the
+            independent variable used for generating the finite
+            difference weights.
+            If it is a coefficient, it will be used as the step-size
+            for generating an equidistant sequence of length order+1
+            centered around x0. default: 1 (step-size 1)
+        x0 : number or Symbol, optional
+            the value of the independent variable (wrt) at which the
+            derivative is to be approximated. default: same as wrt
+        wrt : Symbol, optional
+            "with respect to" the variable for which the (partial)
+            derivative is to be approximated for. If not provided it
+            is required that the Derivative is ordinary. default: None
+
+
+        Examples
+        ========
+        >>> from sympy import symbols, Function, exp, sqrt, Symbol
+        >>> x, h = symbols('x h')
+        >>> f = Function('f')
+        >>> f(x).diff(x).as_finite_difference()
+        -f(x - 1/2) + f(x + 1/2)
+
+        The default step size and number of points are 1 and
+        ``order + 1`` respectively. We can change the step size by
+        passing a symbol as a parameter:
+
+        >>> f(x).diff(x).as_finite_difference(h)
+        -f(-h/2 + x)/h + f(h/2 + x)/h
+
+        We can also specify the discretized values to be used in a
+        sequence:
+
+        >>> f(x).diff(x).as_finite_difference([x, x+h, x+2*h])
+        -3*f(x)/(2*h) + 2*f(h + x)/h - f(2*h + x)/(2*h)
+
+        The algorithm is not restricted to use equidistant spacing, nor
+        do we need to make the approximation around x0, but we can get
+        an expression estimating the derivative at an offset:
+
+        >>> e, sq2 = exp(1), sqrt(2)
+        >>> xl = [x-h, x+h, x+e*h]
+        >>> f(x).diff(x, 1).as_finite_difference(xl, x+h*sq2)
+        2*h*((h + sqrt(2)*h)/(2*h) - (-sqrt(2)*h + h)/(2*h))*f(E*h + x)/\
+((-h + E*h)*(h + E*h)) + (-(-sqrt(2)*h + h)/(2*h) - \
+(-sqrt(2)*h + E*h)/(2*h))*f(-h + x)/(h + E*h) + \
+(-(h + sqrt(2)*h)/(2*h) + (-sqrt(2)*h + E*h)/(2*h))*f(h + x)/(-h + E*h)
+
+        Partial derivatives are also supported:
+
+        >>> y = Symbol('y')
+        >>> d2fdxdy=f(x,y).diff(x,y)
+        >>> d2fdxdy.as_finite_difference(wrt=x)
+        -Derivative(f(x - 1/2, y), y) + Derivative(f(x + 1/2, y), y)
+
+        See also
+        ========
+
+        sympy.calculus.finite_diff.apply_finite_diff
+        sympy.calculus.finite_diff.differentiate_finite
+        sympy.calculus.finite_diff.finite_diff_weights
+
+        """
+        from ..calculus.finite_diff import _as_finite_diff
+        return _as_finite_diff(self, points, x0, wrt)
+
 
 class Lambda(Expr):
     """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1428,6 +1428,14 @@ class Derivative(Expr):
         >>> d2fdxdy.as_finite_difference(wrt=x)
         -Derivative(f(x - 1/2, y), y) + Derivative(f(x + 1/2, y), y)
 
+        We can apply ``as_finite_difference`` to ``Derivative`` insatnces in
+        compound expressions using ``replace``:
+
+        >>> (1 + 42**f(x).diff(x)).replace(lambda arg: arg.is_Derivative,
+        ...     lambda arg: arg.as_finite_difference())
+        42**(-f(x - 1/2) + f(x + 1/2)) + 1
+
+
         See also
         ========
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -711,3 +711,96 @@ def test_issue_8469():
 def test_should_evalf():
     # This should not take forever to run (see #8506)
     assert isinstance(sin((1.0 + 1.0*I)**10000 + 1), sin)
+
+
+def test_Derivative_as_finite_difference():
+    # Central 1st derivative at gridpoint
+    x, h = symbols('x h', real=True)
+    dfdx = f(x).diff(x)
+    assert (dfdx.as_finite_difference([x-2, x-1, x, x+1, x+2]) -
+            (S(1)/12*(f(x-2)-f(x+2)) + S(2)/3*(f(x+1)-f(x-1)))).simplify() == 0
+
+    # Central 1st derivative "half-way"
+    assert (dfdx.as_finite_difference() -
+            (f(x + S(1)/2)-f(x - S(1)/2))).simplify() == 0
+    assert (dfdx.as_finite_difference(h) -
+            (f(x + h/S(2))-f(x - h/S(2)))/h).simplify() == 0
+    assert (dfdx.as_finite_difference([x - 3*h, x-h, x+h, x + 3*h]) -
+            (S(9)/(8*2*h)*(f(x+h) - f(x-h)) +
+             S(1)/(24*2*h)*(f(x - 3*h) - f(x + 3*h)))).simplify() == 0
+
+    # One sided 1st derivative at gridpoint
+    assert (dfdx.as_finite_difference([0, 1, 2], 0) -
+            (-S(3)/2*f(0) + 2*f(1) - f(2)/2)).simplify() == 0
+    assert (dfdx.as_finite_difference([x, x+h], x) -
+            (f(x+h) - f(x))/h).simplify() == 0
+    assert (dfdx.as_finite_difference([x-h, x, x+h], x-h) -
+            (-S(3)/(2*h)*f(x-h) + 2/h*f(x) -
+             S(1)/(2*h)*f(x+h))).simplify() == 0
+
+    # One sided 1st derivative "half-way"
+    assert (dfdx.as_finite_difference([x-h, x+h, x + 3*h, x + 5*h, x + 7*h])
+            - 1/(2*h)*(-S(11)/(12)*f(x-h) + S(17)/(24)*f(x+h)
+                       + S(3)/8*f(x + 3*h) - S(5)/24*f(x + 5*h)
+                       + S(1)/24*f(x + 7*h))).simplify() == 0
+
+    d2fdx2 = f(x).diff(x, 2)
+    # Central 2nd derivative at gridpoint
+    assert (d2fdx2.as_finite_difference([x-h, x, x+h]) -
+            h**-2 * (f(x-h) + f(x+h) - 2*f(x))).simplify() == 0
+
+    assert (d2fdx2.as_finite_difference([x - 2*h, x-h, x, x+h, x + 2*h]) -
+            h**-2 * (-S(1)/12*(f(x - 2*h) + f(x + 2*h)) +
+                     S(4)/3*(f(x+h) + f(x-h)) - S(5)/2*f(x))).simplify() == 0
+
+    # Central 2nd derivative "half-way"
+    assert (d2fdx2.as_finite_difference([x - 3*h, x-h, x+h, x + 3*h]) -
+            (2*h)**-2 * (S(1)/2*(f(x - 3*h) + f(x + 3*h)) -
+                         S(1)/2*(f(x+h) + f(x-h)))).simplify() == 0
+
+    # One sided 2nd derivative at gridpoint
+    assert (d2fdx2.as_finite_difference([x, x+h, x + 2*h, x + 3*h]) -
+            h**-2 * (2*f(x) - 5*f(x+h) +
+                     4*f(x+2*h) - f(x+3*h))).simplify() == 0
+
+    # One sided 2nd derivative at "half-way"
+    assert (d2fdx2.as_finite_difference([x-h, x+h, x + 3*h, x + 5*h]) -
+            (2*h)**-2 * (S(3)/2*f(x-h) - S(7)/2*f(x+h) + S(5)/2*f(x + 3*h) -
+                         S(1)/2*f(x + 5*h))).simplify() == 0
+
+    d3fdx3 = f(x).diff(x, 3)
+    # Central 3rd derivative at gridpoint
+    assert (d3fdx3.as_finite_difference() -
+            (-f(x - 3/S(2)) + 3*f(x - 1/S(2)) -
+             3*f(x + 1/S(2)) + f(x + 3/S(2)))).simplify() == 0
+
+    assert (d3fdx3.as_finite_difference(
+        [x - 3*h, x - 2*h, x-h, x, x+h, x + 2*h, x + 3*h]) -
+        h**-3 * (S(1)/8*(f(x - 3*h) - f(x + 3*h)) - f(x - 2*h) +
+                 f(x + 2*h) + S(13)/8*(f(x-h) - f(x+h)))).simplify() == 0
+
+    # Central 3rd derivative at "half-way"
+    assert (d3fdx3.as_finite_difference([x - 3*h, x-h, x+h, x + 3*h]) -
+            (2*h)**-3 * (f(x + 3*h)-f(x - 3*h) +
+                         3*(f(x-h)-f(x+h)))).simplify() == 0
+
+    # One sided 3rd derivative at gridpoint
+    assert (d3fdx3.as_finite_difference([x, x+h, x + 2*h, x + 3*h]) -
+            h**-3 * (f(x + 3*h)-f(x) + 3*(f(x+h)-f(x + 2*h)))).simplify() == 0
+
+    # One sided 3rd derivative at "half-way"
+    assert (d3fdx3.as_finite_difference([x-h, x+h, x + 3*h, x + 5*h]) -
+            (2*h)**-3 * (f(x + 5*h)-f(x-h) +
+                         3*(f(x+h)-f(x + 3*h)))).simplify() == 0
+
+    # issue 11007
+    y = Symbol('y', real=True)
+    d2fdxdy = f(x, y).diff(x, y)
+
+    ref0 = Derivative(f(x + S(1)/2, y), y) - Derivative(f(x - S(1)/2, y), y)
+    assert (d2fdxdy.as_finite_difference(wrt=x) - ref0).simplify() == 0
+
+    half = S(1)/2
+    xm, xp, ym, yp = x-half, x+half, y-half, y+half
+    ref2 = f(xm, ym) + f(xp, yp) - f(xp, ym) - f(xm, yp)
+    assert (d2fdxdy.as_finite_difference() - ref2).simplify() == 0


### PR DESCRIPTION
- Deprecates as_finite_diff
- New function: differentiate_finite
- New method: Derivative.as_finite_difference
