### PR TITLE
some low hanging fruit...

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -25,6 +25,8 @@ AST Type Tree
        |        |--->Attribute
        |        |--->For
        |        |--->String
+       |        |       |--->QuotedString
+       |        |       |--->Comment
        |        |--->Type
        |        |       |--->IntBaseType
        |        |       |              |--->_SizedIntType
@@ -730,6 +732,8 @@ class String(Token):
 class QuotedString(String):
     """ Represents a string which should be printed with quotes. """
 
+class Comment(String):
+    """ Represents a comment. """
 
 class Node(Token):
     """ Subclass of Token, carrying the attribute 'attrs' (Tuple)

--- a/sympy/codegen/tests/test_ast.py
+++ b/sympy/codegen/tests/test_ast.py
@@ -13,7 +13,7 @@ from sympy.codegen.ast import (
     integer, real, complex_, int8, uint8, float16 as f16, float32 as f32,
     float64 as f64, float80 as f80, float128 as f128, complex64 as c64, complex128 as c128,
     While, Scope, String, Print, QuotedString, FunctionPrototype, FunctionDefinition, Return,
-    FunctionCall, untyped, IntBaseType, intc, Node, none, NoneToken, Token
+    FunctionCall, untyped, IntBaseType, intc, Node, none, NoneToken, Token, Comment
 )
 
 x, y, z, t, x0 = symbols("x, y, z, t, x0")
@@ -221,6 +221,10 @@ def test_String():
     assert str(s) == 'foo'
     assert repr(s) == "String('foo')"
 
+def test_Comment():
+    c = Comment('foobar')
+    assert c.text == 'foobar'
+    assert str(c) == 'foobar'
 
 def test_Node():
     n = Node()

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -189,7 +189,6 @@ def test_sympy__codegen__ast__NoneToken():
     from sympy.codegen.ast import NoneToken
     assert _test_args(NoneToken())
 
-
 def test_sympy__codegen__ast__String():
     from sympy.codegen.ast import String
     assert _test_args(String('foobar'))
@@ -198,6 +197,9 @@ def test_sympy__codegen__ast__QuotedString():
     from sympy.codegen.ast import QuotedString
     assert _test_args(QuotedString('foobar'))
 
+def test_sympy__codegen__ast__Comment():
+    from sympy.codegen.ast import Comment
+    assert _test_args(Comment('this is a comment'))
 
 def test_sympy__codegen__ast__Node():
     from sympy.codegen.ast import Node

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -288,6 +288,9 @@ class CodePrinter(StrPrinter):
     def _print_QuotedString(self, arg, **kwargs):
         return '"%s"' % arg.text
 
+    def _print_Comment(self, string, **kwargs):
+        return self._get_comment(str(string), **kwargs)
+
     def _print_Assignment(self, expr, **kwargs):
         from sympy.functions.elementary.piecewise import Piecewise
         from sympy.matrices.expressions.matexpr import MatrixSymbol

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -16,7 +16,7 @@ from sympy.printing.ccode import CCodePrinter, C89CodePrinter, C99CodePrinter, g
 from sympy.codegen.ast import (
     AddAugmentedAssignment, Element, Type, FloatType, Declaration, Pointer, Variable, value_const, pointer_const,
     While, Scope, Print, FunctionPrototype, FunctionDefinition, FunctionCall, Statement, Return,
-    real, float32, float64, float80, float128, intc
+    real, float32, float64, float80, float128, intc, Comment
 )
 from sympy.codegen.cfunctions import expm1, log1p, exp2, log2, fma, log10, Cbrt, hypot, Sqrt
 from sympy.codegen.cnodes import restrict
@@ -804,6 +804,7 @@ def test_ccode_Type():
 
 
 def test_ccode_codegen_ast():
+    assert ccode(Comment("this is a comment")) == "// this is a comment"
     assert ccode(While(abs(x) > 1, [aug_assign(x, '-', 1)])) == (
         'while (fabs(x) > 1) {\n'
         '   x -= 1;\n'


### PR DESCRIPTION
Added Comment to the ast. Just looking for a simple place to start. Wasn't really sure what to do in test_ast.py. Also wasn't sure if I should put a test in test_ccode.py or not.

The printer (for ccode at least) doesn't seem to support /* multi line comments */ (if the string contains \n for example) Would that be implemented as a new type? or should ccode._get_comment() handle that? I could also see it being an option passed in a kwarg to _get_comment but it doesn't have kwargs right now.