### PR TITLE
Account for free symbols in codegen.ast.CodeBlock

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -556,6 +556,14 @@ class CodeBlock(Basic):
 
         """
         from sympy.utilities.iterables import topological_sort
+
+        if not all(isinstance(i, Assignment) for i in assignments):
+            # Will support more things later
+            raise NotImplementedError("CodeBlock.topological_sort only supports Assignments")
+
+        if any(isinstance(i, AugmentedAssignment) for i in assignments):
+            raise NotImplementedError("CodeBlock.topological_sort doesn't yet work with AugmentedAssignments")
+
         # Create a graph where the nodes are assignments and there is a directed edge
         # between nodes that use a variable and nodes that assign that
         # variable, like

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -125,6 +125,7 @@ from __future__ import print_function, division
 
 from functools import total_ordering
 from itertools import chain
+from collections import defaultdict
 from sympy.core import Symbol, Tuple, Dummy
 from sympy.core.basic import Basic
 from sympy.core.expr import Expr
@@ -465,6 +466,8 @@ class CodeBlock(Basic):
         Tuple of left-hand sides of assignments, in order.
     ``left_hand_sides``:
         Tuple of right-hand sides of assignments, in order.
+    ``free_symbols``: Free symbols of the expressions in the right-hand sides
+        which do not appear in the left-hand side of an assignment.
 
     Useful methods on this object are:
 
@@ -514,6 +517,10 @@ class CodeBlock(Basic):
                 ' '*il + joined + '\n' + ' '*(il - 4) + ')')
 
     _sympystr = _sympyrepr
+
+    @property
+    def free_symbols(self):
+        return super(CodeBlock, self).free_symbols - set(self.left_hand_sides)
 
     @classmethod
     def topological_sort(cls, assignments):
@@ -569,26 +576,25 @@ class CodeBlock(Basic):
         # the same variable when those are implemented.
         A = list(enumerate(assignments))
 
-        # var_map = {variable: [assignments using variable]}
-        # like {x: [y := x + 1, z := y + x], ...}
-        var_map = {}
+        # var_map = {variable: [nodes for which this variable is assigned to]}
+        # like {x: [(1, x := y + z), (4, x := 2 * w)], ...}
+        var_map = defaultdict(list)
+        for node in A:
+            i, a = node
+            var_map[a.lhs].append(node)
 
         # E = Edges in the graph
         E = []
-        for i in A:
-            if i[1].lhs in var_map:
-                E.append((var_map[i[1].lhs], i))
-            var_map[i[1].lhs] = i
-        for i in A:
-            for x in i[1].rhs.free_symbols:
-                if x not in var_map:
-                    # XXX: Allow this case?
-                    raise ValueError("Undefined variable %s" % x)
-                E.append((var_map[x], i))
+        for dst_node in A:
+            i, a = dst_node
+            for s in a.rhs.free_symbols:
+                for src_node in var_map[s]:
+                    E.append((src_node, dst_node))
 
         ordered_assignments = topological_sort([A, E])
+
         # De-enumerate the result
-        return cls(*list(zip(*ordered_assignments))[1])
+        return cls(*[a for i, a in ordered_assignments])
 
     def cse(self, symbols=None, optimizations=None, postprocess=None,
         order='canonical'):

--- a/sympy/codegen/tests/test_ast.py
+++ b/sympy/codegen/tests/test_ast.py
@@ -16,7 +16,7 @@ from sympy.codegen.ast import (
     FunctionCall, untyped, IntBaseType, intc, Node, none, NoneToken, Token, Comment
 )
 
-x, y, z, t, x0 = symbols("x, y, z, t, x0")
+x, y, z, t, x0, a, b = symbols("x, y, z, t, x0, a, b")
 n = symbols("n", integer=True)
 A = MatrixSymbol('A', 3, 1)
 mat = Matrix([1, 2, 3])
@@ -144,12 +144,40 @@ def test_CodeBlock_topological_sort():
 
     raises(ValueError, lambda: CodeBlock.topological_sort(invalid_assignments))
 
-    # Undefined variable
-    invalid_assignments = [
-        Assignment(x, y)
+    # Free symbols
+    free_assignments = [
+        Assignment(x, y + z),
+        Assignment(z, a * b),
+        Assignment(t, x),
+        Assignment(y, b + 3),
         ]
 
-    raises(ValueError, lambda: CodeBlock.topological_sort(invalid_assignments))
+    free_assignments_ordered = [
+        Assignment(z, a * b),
+        Assignment(y, b + 3),
+        Assignment(x, y + z),
+        Assignment(t, x),
+        ]
+
+    c = CodeBlock.topological_sort(assignments)
+    assert c == CodeBlock(*ordered_assignments)
+
+def test_CodeBlock_free_symbols():
+    c1 = CodeBlock(
+        Assignment(x, y + z),
+        Assignment(z, 1),
+        Assignment(t, x),
+        Assignment(y, 2),
+        )
+    assert c1.free_symbols == set()
+
+    c2 = CodeBlock(
+        Assignment(x, y + z),
+        Assignment(z, a * b),
+        Assignment(t, x),
+        Assignment(y, b + 3),
+    )
+    assert c2.free_symbols == {a, b}
 
 def test_CodeBlock_cse():
     c = CodeBlock(


### PR DESCRIPTION
Currently `CodeBlock.topological_sort` raises an exception if an unknown variable is encountered in the assignments:

```python console
>>> from sympy.abc import x, y, z, t, a, b, c
>>> from sympy.codegen.ast import CodeBlock, Assignment
>>> assignments = [ 
...     Assignment(x, y + z),
...     Assignment(z, a * b),
...     Assignment(t, x),
...     Assignment(y, c + 3),
... ]
>>> cb = CodeBlock.topological_sort(assignments)
ValueError: Undefined variable a
```

I think it is important this be allowed, so that code blocks can be used inside of e.g. function bodies. Currently they only allow assignments that can be evaluated to constants at compile time, which isn't too useful.

I've changed the `topological_sort` method to ignore unknown symbols (as well as cleaning it up a bit), and overloaded the `free_symbols` property to exclude all symbols which are assigned to. Therefore you have

```python console
>>> cb = CodeBlock.topological_sort(assignments)
>>> cb
CodeBlock(
    Assignment(z, a*b),
    Assignment(y, c + 3),
    Assignment(x, y + z),
    Assignment(t, x)
)
>>> cb.free_symbols
{a, b, c}
```

The `free_symbols` property can be checked to ensure that they all appear as function arguments, for example.